### PR TITLE
Further performance and RAM usage improvements: batch inserts

### DIFF
--- a/tests/test-neo4j-insertion.py
+++ b/tests/test-neo4j-insertion.py
@@ -16,7 +16,6 @@ from wsyntree.tree_models import (
 )
 from wsyntree_collector import neo4j_collector_worker as wst_n4j_worker
 
-log.setLevel(log.DEBUG)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -32,8 +31,14 @@ if __name__ == '__main__':
         type=str,
         help="File to parse"
     )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+    )
 
     args = parser.parse_args()
+    if args.verbose:
+        log.setLevel(log.DEBUG)
 
     if "NEO4J_BOLT_URL" in os.environ:
         neoconfig.DATABASE_URL = os.environ["NEO4J_BOLT_URL"]

--- a/tests/test-neo4j-insertion.py
+++ b/tests/test-neo4j-insertion.py
@@ -69,10 +69,11 @@ if __name__ == '__main__':
         node_receiver = wst_n4j_worker._tqdm_node_receiver(_node_queue)
 
         try:
-            cProfile.run(
-                f'wst_n4j_worker._process_file(args.file_path, repo, node_q=_node_queue, notify_every=10)',
+            r = cProfile.run(
+                f'wst_n4j_worker._process_file(args.file_path, repo, node_q=_node_queue, batch_write_size=100)',
                 "test-insertion.prof",
             )
+            log.info(f"{r}")
         # except KeyboardInterrupt as e:
         #     log.warn(f"stopping collection ...")
         finally:

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,8 +6,6 @@ from wsyntree import log
 from wsyntree.utils import node_as_sexp
 from wsyntree.wrap_tree_sitter import TreeSitterAutoBuiltLanguage, TreeSitterCursorIterator
 
-log.setLevel(log.DEBUG)
-
 def str_tsnode(n):
     return f"tsnode<{n.type}, {n.start_point}>"
 
@@ -25,8 +23,14 @@ if __name__ == '__main__':
         type=str,
         help="File to parse"
     )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+    )
 
     args = parser.parse_args()
+    if args.verbose:
+        log.setLevel(log.DEBUG)
 
     lang = TreeSitterAutoBuiltLanguage(args.language)
 
@@ -40,5 +44,5 @@ if __name__ == '__main__':
     root = cur.peek()
 
     for node in cur:
-        log.debug(node)
+        print(node)
         log.info(f"{'  ' * cur.depth}{str_tsnode(node)}")

--- a/wsyntree/tree_models.py
+++ b/wsyntree/tree_models.py
@@ -41,7 +41,7 @@ class WSTFile(StructuredNode):
     wstnodes = RelationshipFrom("WSTNode", 'IN_FILE')
 
 class WSTText(StructuredNode):
-    length = IntegerProperty(required=True)
+    length = IntegerProperty(index=True, required=True)
 
     used_by = RelationshipFrom("WSTNode", 'CONTENT')
 

--- a/wsyntree/tree_models.py
+++ b/wsyntree/tree_models.py
@@ -53,10 +53,16 @@ class WSTHugeText(WSTText):
     text = StringProperty(index=False, required=True)
 
 class WSTNode(StructuredNode):
+    # x: line, y: character (2d coords begin->end)
     x1 = IntegerProperty(required=True)
     y1 = IntegerProperty(required=True)
     x2 = IntegerProperty(required=True)
     y2 = IntegerProperty(required=True)
+
+    # preorder: depth-first traversal order, unique within file
+    # aka: topologically sorted
+    # root node is zero and has no parent
+    preorder = IntegerProperty(index=True, required=True)
 
     named = BooleanProperty(required=True)
     type = StringProperty(index=True)

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -50,7 +50,8 @@ def create_WSTNode_root(tx, data: dict) -> int:
     record = result.single()
     return record["node_id"]
 
-@neo4j.unit_of_work(timeout=10000)
+# milliseconds timeout
+@neo4j.unit_of_work(timeout=30 * 60 * 1000)
 def managed_batch_insert(tx, entries: list, order_to_id_o: dict) -> dict:
     order_to_id = order_to_id_o.copy() # stay pure until tx successful
     qi = """

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -20,13 +20,13 @@ from wsyntree.wrap_tree_sitter import get_TSABL_for_file
 
 @concurrent.process
 def _tqdm_node_receiver(q):
-    log.debug(f"started counting added nodes from {q}")
+    log.debug(f"started counting added nodes")
     n = 0
-    with tqdm(desc="adding nodes to db", position=1) as tbar:
+    with tqdm(desc="adding nodes to db", position=1, unit='nodes', unit_scale=True) as tbar:
         while (nc := q.get()) is not None:
             n += nc
             tbar.update(nc)
-    log.debug(f"stopped counting nodes: total WSTNodes added: {n}")
+    log.info(f"stopped counting nodes, total WSTNodes added: {n}")
 
 def create_WSTNode(tx, data: dict) -> int:
     if "parentid" in data:
@@ -185,7 +185,7 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
                 if node_q and nc >= notify_every:
                     node_q.put(nc)
                     nc = 0
-                    if not t_notified and time.time() > t_start + (5*60):
+                    if not t_notified and time.time() > t_start + (30*60):
                         log.warn(f"{file}: processing taking longer than expected.")
                         t_notified = True
 

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -108,7 +108,7 @@ def _process_file(
         tree_repo: WSTRepository,
         *,
         node_q = None,
-        batch_write_size=1000,
+        batch_write_size=100,
     ):
     """Runs one file's analysis from a repo.
 

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -107,7 +107,7 @@ def _process_file(
         tree_repo: WSTRepository,
         *,
         node_q = None,
-        batch_write_size=10000,
+        batch_write_size=1000,
     ):
     """Runs one file's analysis from a repo.
 

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -50,24 +50,6 @@ def create_WSTNode_root(tx, data: dict) -> int:
     record = result.single()
     return record["node_id"]
 
-# def create_WSTNode(tx, data: dict) -> int:
-#     # text = data['text']
-#     # n_t = "WSTIndexableText" if len(text) <= 4e3 else "WSTHugeText"
-#     q = """
-#     match (f:WSTFile), (p:WSTNode)
-#     where id(f) = $fileid and id(p) = $parentid
-#     create (p)<-[:PARENT]-(nn:WSTNode {
-#         x1: $x1, x2: $x2, y1: $y1, y2: $y2,
-#         named: $named, type: $type
-#     })-[:IN_FILE]->(f), (nn)-[:CONTENT]->(t:WSTText {
-#         length: $textlength,
-#         text: $text
-#     })
-#     return id(nn) as node_id"""
-#     result = tx.run(q, data)
-#     record = result.single()
-#     return record["node_id"]
-
 def batch_insert_WSTNode(tx, entries: list) -> int:
     q = """
     unwind $entries as data
@@ -98,22 +80,6 @@ def batch_insert_WSTNode(tx, entries: list) -> int:
     assert len(nvals) == len(entries), f"Ensure all nodes were created."
 
     return nvals
-
-# def WSTNode_add_text(tx, nodeid, text):
-#     result = tx.run(
-#         """match (n:WSTNode)
-#         where id(n) = $nodeid
-#         create (n)-[r:CONTENT]->(t:WSTTest:"""+n_t+""" {
-#             length: $length,
-#             text: $text
-#         })
-#         return id(t) as text_id""",
-#         nodeid=nodeid,
-#         length=len(text),
-#         text=text,
-#     )
-#     record = result.single()
-#     return record["text_id"]
 
 def _process_file(
         path: Path,

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -28,7 +28,7 @@ def _tqdm_node_receiver(q):
             tbar.update(nc)
     log.debug(f"stopped counting nodes: total WSTNodes added: {n}")
 
-def create_WSTNode(tx, data: dict, fileid) -> int:
+def create_WSTNode(tx, data: dict) -> int:
     result = tx.run(
         """
         match (f:WSTFile)
@@ -141,6 +141,7 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
                 nnd = dotdict({
                     "named": cur_node.is_named,
                     "type": cur_node.type,
+                    "fileid": file.id,
                 })
                 (nnd.x1,nnd.y1) = cur_node.start_point
                 (nnd.x2,nnd.y2) = cur_node.end_point
@@ -151,7 +152,7 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
 
                 # insert data into the database
                 with session.begin_transaction() as tx:
-                    nnid = create_WSTNode(tx, nnd, file.id)
+                    nnid = create_WSTNode(tx, nnd)
                     # WSTNode_set_file(tx, nnid, file.id)
 
                     if parentid is not None:

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -141,6 +141,8 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
     )
 
     # log.debug(f"growing nodes for {file}")
+    t_start = time.time()
+    t_notified = False
     cursor = tree.walk()
     # iteration loop
     nc = 0
@@ -183,6 +185,9 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
                 if node_q and nc >= notify_every:
                     node_q.put(nc)
                     nc = 0
+                    if not t_notified and time.time() > t_start + (5*60):
+                        log.warn(f"{file}: processing taking longer than expected.")
+                        t_notified = True
 
                 # now determine where to move to next:
                 next_child = cursor.goto_first_child()

--- a/wsyntree_collector/neo4j_collector_worker.py
+++ b/wsyntree_collector/neo4j_collector_worker.py
@@ -130,7 +130,7 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
     nc = 0
     parent_stack = []
     try:
-        with driver.session() as session, session.begin_transaction() as tx:
+        with driver.session() as session:
             # definitions: nn = new node, nt = new text, nc = node count
             while cursor.node is not None:
                 cur_node = cursor.node
@@ -146,7 +146,7 @@ def _process_file(path: Path, tree_repo: WSTRepository, *, node_q = None, notify
                     parentid = parent_stack[-1]
 
                 # insert data into the database
-                with nullcontext():
+                with session.begin_transaction() as tx:
                     nnid = create_WSTNode(tx, nnd)
                     WSTNode_set_file(tx, nnid, file.id)
 


### PR DESCRIPTION
Figured out how to a constant-time batch write with only two queries! (Python is still O(N) but N is capped at the size of a single file's nodes, which are cheap to iterate)

Since it is (theoretically) constant-time inserts now, this *should* mean that it's ready for analyzing all of github, please compare results in both performance and in terms of tree correctness.

I also added the `preorder` property, which is the Pre-Order series number in the depth-first tree traversal. This should allow us to develop a test suite to compare Tree Sitter trees from TreeSitterCursorIterator to data in neo4j directly. (by item to item sequence comparison)