### PR TITLE
Hash-based keys for node text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - $HOME/.cache/wsyntree
 
 install:
+  - python -m pip install requests coloredlogs pygit2
   - python -m pip install -r requirements.txt
   - python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         "tree_sitter@git+https://github.com/utk-se/py-tree-sitter.git@master",
         "tqdm",
         "Pebble",
-        "filelock"
+        "filelock",
+        "cachetools",
     ],
     entry_points={
         'console_scripts': [

--- a/wsyntree/tree_models.py
+++ b/wsyntree/tree_models.py
@@ -171,6 +171,17 @@ class WSTText(WST_Document):
         "text",
     ]
 
+    def insert_in_db(self, db: Union[StandardDatabase, BatchDatabase]):
+        """WSTTexts might be duplicate
+
+        We prevent errors during insert if the document already exists:
+        They are perfectly equivalent, enforced by the key having the hash of text,
+        thus we will never lose data with overwrite
+        """
+        assert self._key
+        coll = db.collection(self._collection)
+        return coll.insert(self.__dict__, overwrite_mode="replace")
+
     # used_by = RelationshipFrom("WSTNode", 'CONTENT')
 
 class WSTNode(WST_Document):

--- a/wsyntree/utils.py
+++ b/wsyntree/utils.py
@@ -67,9 +67,16 @@ def chunkiter(seq, size):
     while chunk := tuple(itertools.islice(it, size)):
         yield chunk
 
-def strip_url(u):
+def strip_url(u: str):
     p = urlparse(u)
     return f"{p.scheme}://{p.hostname}:{p.port}"
 
+def desensitize_url(u: str):
+    p = urlparse(u)
+    return f"{p.scheme}://{p.username}@{p.hostname}:{p.port}{p.path}"
+
 def sha1hex(s: str) -> str:
     return hashlib.sha1(s.encode()).hexdigest()
+
+def sha512hex(b: bytes) -> str:
+    return hashlib.sha512(b).hexdigest()

--- a/wsyntree_collector/__main__.py
+++ b/wsyntree_collector/__main__.py
@@ -11,7 +11,7 @@ from arango import ArangoClient
 
 from wsyntree import log
 from wsyntree.wrap_tree_sitter import TreeSitterAutoBuiltLanguage, TreeSitterCursorIterator
-from wsyntree.utils import strip_url
+from wsyntree.utils import strip_url, desensitize_url
 from wsyntree.tree_models import WSTRepository
 
 from .arango_collector import WST_ArangoTreeCollector
@@ -105,8 +105,8 @@ def database_init(args):
                 log.debug(f"delete: waiting on {len(jobs)} jobs to finish ...")
                 jt_wait = len(jobs)
 
-        # back to non-async
-        db = odb
+    # back to non-async
+    db = odb
 
     log.info(f"Creating collections ...")
 
@@ -198,6 +198,8 @@ def __main__():
     if args.verbose:
         log.setLevel(log.DEBUG)
         log.debug("Verbose logging enabled.")
+
+    log.info(f"DB connection: {desensitize_url(args.db)}")
 
     if 'func' not in args:
         log.warn(f"Please supply a valid subcommand!")

--- a/wsyntree_collector/arango_collector.py
+++ b/wsyntree_collector/arango_collector.py
@@ -17,7 +17,9 @@ from pebble import ProcessPool, ThreadPool
 from wsyntree import log, tree_models
 from wsyntree.tree_models import * # __all__
 from wsyntree.localstorage import LocalCache
-from wsyntree.utils import list_all_git_files, pushd, strip_url, sha1hex, chunkiter
+from wsyntree.utils import (
+    list_all_git_files, pushd, strip_url, sha1hex, chunkiter
+)
 from .arango_collector_worker import _tqdm_node_receiver, process_file
 
 

--- a/wsyntree_collector/arango_collector.py
+++ b/wsyntree_collector/arango_collector.py
@@ -140,6 +140,8 @@ class WST_ArangoTreeCollector():
             log.info(f"Repo status {self._tree_repo.wst_status} -> deleting")
             self._tree_repo.wst_status = "deleting"
             self._tree_repo.update_in_db(self._db)
+        else:
+            log.info(f"Resuming deletion ...")
 
         nodechunksize = 1000
         files = WSTFile.iterate_from_parent(self._db, self._tree_repo)
@@ -250,6 +252,7 @@ class WST_ArangoTreeCollector():
                 finally:
                     self._node_queue.put(None)
             self._node_queue.put(None)
+            receiver_exit = node_receiver.result(timeout=3)
 
     def setup(self):
         """Clone the repo, connect to the DB, create working directories, etc."""


### PR DESCRIPTION
logN lookup time should be just fine for the WSTText indexes.

Using the SHA512 hash of the text content deals with the text uniqueness constraint and also is a much more clear differentiation compared to using a text index.

Since 512 bits in hex fits within the max key spec, I added the text length to the key as well, for the infinitesimally small chance we encounter the pigeonhole principle lol